### PR TITLE
[G2M] flow - panel design zpl.io/agAX4W0, better selected node logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-d3-graph": "^2.1.0",
     "react-flow-renderer": "^5.1.0",
     "react-resize-aware": "^3.0.1",
+    "react-virtualized-auto-sizer": "^1.0.2",
     "uuid": "^3.3.3"
   },
   "devDependencies": {

--- a/src/flow/common.js
+++ b/src/flow/common.js
@@ -1,0 +1,18 @@
+import { createElement } from 'react'
+import { styled, setup } from 'goober'
+
+
+setup(createElement)
+
+export const Dot = styled('span')`
+  height: 0.5rem;
+  width: 0.5rem;
+  background-color: ${({ state }) => ({
+    failed: '#ea0000;',
+    success: '#00d308;',
+    running: '#009aff;',
+    skipped: '#eeeeee;',
+  }[state] || '#eeeeee')};
+  border-radius: 50%;
+  display: inline-block;
+`

--- a/src/flow/dag-node.js
+++ b/src/flow/dag-node.js
@@ -16,6 +16,11 @@ export const NodeContent = styled('div')`
   font-size: 0.9rem;
   border-radius: 10px;
   border: solid 1px ${({ selected }) => selected ? '#0075ff' : '#bdbdbd'};
+  transition: background .2s;
+  &:hover {
+    background-color: #e2f3ff;
+    border: solid 1px #8bceff;
+  }
 `
 
 const DAGNode = ({ id, data: { name, sub, level, period, dag = {} } }) => {

--- a/src/flow/dag-node.js
+++ b/src/flow/dag-node.js
@@ -13,7 +13,7 @@ export const NodeContent = styled('div')`
   max-width: 275px;
   overflow: auto;
   padding: 1rem;
-  font-size: 1rem;
+  font-size: 0.9rem;
   border-radius: 10px;
   border: solid 1px ${({ selected }) => selected ? '#0075ff' : '#bdbdbd'};
 `

--- a/src/flow/dag-node.js
+++ b/src/flow/dag-node.js
@@ -1,8 +1,10 @@
-import React, { createElement, useState, useRef, useEffect } from 'react'
+import React, { createElement } from 'react'
 import PropTypes from 'prop-types'
 
 import { styled, setup } from 'goober'
-import { Handle } from 'react-flow-renderer'
+import { Handle, useStoreState } from 'react-flow-renderer'
+
+import { Dot } from './common'
 
 
 setup(createElement)
@@ -16,54 +18,27 @@ export const NodeContent = styled('div')`
   border: solid 1px ${({ selected }) => selected ? '#0075ff' : '#bdbdbd'};
 `
 
-export const Dot = styled('span')`
-  height: 0.5rem;
-  width: 0.5rem;
-  margin-right: 0.5rem;
-  background-color: ${({ state }) => ({
-    failed: '#ea0000;',
-    success: '#00d308;',
-    running: '#009aff;',
-    skipped: '#eeeeee;',
-  }[state] || '#eeeeee')};
-  border-radius: 50%;
-  display: inline-block;
-`
-
-const DAGNode = ({ data: { name, sub, level, period, dag = {} } }) => {
-  const ref = useRef(null)
-  const [selected, setSelected] = useState(false)
-
-  // based on https://stackoverflow.com/a/42234988/158111
-  useEffect(() => {
-    function handleClickAway(event) {
-      if (ref.current && !ref.current.contains(event.target)) {
-        setSelected(false)
-      }
-    }
-
-    // Bind the event listener
-    document.addEventListener('mousedown', handleClickAway)
-
-    return () => {
-      // Unbind the event listener on clean up
-      document.removeEventListener('mousedown', handleClickAway)
-    }
-  }, [ref])
+const DAGNode = ({ id, data: { name, sub, level, period, dag = {} } }) => {
+  const [{ id: selected } = {}] = useStoreState((store) => store.selectedElements || [])
 
   return (
-    <div ref={ref}>
+    <>
       {level !== 0 && (<Handle type='target' position='left' />)}
-      <NodeContent selected={selected} onClick={() => { setSelected((s) => !s) }} >
+      <NodeContent selected={selected === id}>
         <Dot state={dag.state} />
-        {name}{period ? ` (${period})` : ''}
-        {`: ${sub}`}
+        {' '}
+        {name}
+        {period ? ` (${period})` : ''}
+        {sub ? `: ${sub}` : ''}
       </NodeContent>
       {level !== 3 && (<Handle type='source' position='right' />)}
-    </div>
+    </>
   )
 }
 
-DAGNode.propTypes = { data: PropTypes.object.isRequired }
+DAGNode.propTypes = {
+  id: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired,
+}
 
 export default DAGNode

--- a/src/flow/index.js
+++ b/src/flow/index.js
@@ -1,28 +1,46 @@
-import React from 'react'
+import React, { createElement } from 'react'
 import PropTypes from 'prop-types'
 
-import ReactFlow, { Controls } from 'react-flow-renderer'
-import useResizeAware from 'react-resize-aware'
+import { ReactFlowProvider } from 'react-flow-renderer'
+import AutoSizer from 'react-virtualized-auto-sizer'
+import { styled, setup } from 'goober'
 
 import DAGNode from './dag-node'
-import { useElements } from './hooks'
+import Layout from './layout'
+import Panel from './panel'
 
+
+setup(createElement)
 
 export const nodeTypes = { DAGNode }
 
-const Flow = ({ data, config }) => {
-  const [resizeListner, { width, height }] = useResizeAware()
-  const elements = useElements({ data, config, width, height })
+export const Container = styled('div')`
+  width: inherit;
+  height: inherit;
+  display: flex;
+`
 
-  return (
-    <div style={{ width: 'inherit', height: 'inherit' }}>
-      {resizeListner}
-      <ReactFlow {...{ nodeTypes, ...config }} elements={elements}>
-        <Controls />
-      </ReactFlow>
-    </div>
-  )
-}
+export const FlowContainer = styled('div')`
+  flex: 8;
+  height: inherit;
+  margin: auto;
+  padding-left: 1rem;
+`
+
+const Flow = ({ data, config }) => (
+  <Container>
+    <ReactFlowProvider>
+      <Panel />
+      <FlowContainer>
+        <AutoSizer>
+          {({ width, height }) => (
+            <Layout data={data} config={config} width={width} height={height} />
+          )}
+        </AutoSizer>
+      </FlowContainer>
+    </ReactFlowProvider>
+  </Container>
+)
 
 Flow.propTypes = {
   data: PropTypes.object,

--- a/src/flow/index.js
+++ b/src/flow/index.js
@@ -18,6 +18,7 @@ export const Container = styled('div')`
   width: inherit;
   height: inherit;
   display: flex;
+  font-family: "OpenSans", Helvetica, sans-serif;
 `
 
 export const FlowContainer = styled('div')`

--- a/src/flow/layout.js
+++ b/src/flow/layout.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import ReactFlow, { Controls } from 'react-flow-renderer'
+
+import DAGNode from './dag-node'
+import { useElements } from './hooks'
+
+
+export const nodeTypes = { DAGNode }
+const onLoad = (flow) => flow.fitView()
+
+const Layout = ({ data, config, width, height }) => {
+  console.log(width, height)
+  const elements = useElements({ data, config, width, height })
+
+  return (
+    <div style={{ width, height }}>
+      <ReactFlow {...{ onLoad, nodeTypes, ...config }} elements={elements}>
+        <Controls />
+      </ReactFlow>
+    </div>
+  )
+}
+
+Layout.propTypes = {
+  data: PropTypes.object,
+  config: PropTypes.object,
+  width: PropTypes.number,
+  height: PropTypes.number,
+}
+Layout.defaultProps = {
+  data: {},
+  config: {},
+  width: 1000,
+  height: 800,
+}
+
+export default Layout

--- a/src/flow/layout.js
+++ b/src/flow/layout.js
@@ -11,7 +11,6 @@ export const nodeTypes = { DAGNode }
 const onLoad = (flow) => flow.fitView()
 
 const Layout = ({ data, config, width, height }) => {
-  console.log(width, height)
   const elements = useElements({ data, config, width, height })
 
   return (

--- a/src/flow/panel.js
+++ b/src/flow/panel.js
@@ -19,7 +19,6 @@ export const Container = styled('div')`
 `
 
 export const Title = styled('h3')`
-  font-family: "OpenSans", Helvetica, sans-serif;
   font-size: 1rem;
   font-weight: 600;
   font-stretch: normal;
@@ -29,7 +28,6 @@ export const Title = styled('h3')`
 `
 
 export const Sub = styled('h4')`
-  font-family: "OpenSans", Helvetica, sans-serif;
   font-size: 0.9rem;
   font-weight: 600;
   font-stretch: normal;

--- a/src/flow/panel.js
+++ b/src/flow/panel.js
@@ -1,0 +1,90 @@
+import React, { createElement } from 'react'
+
+import { useStoreState } from 'react-flow-renderer'
+import { styled, setup } from 'goober'
+
+import { Dot } from './common'
+import { humanTime, calcPrice } from './utils'
+
+
+setup(createElement)
+
+export const Container = styled('div')`
+  flex: 2;
+  height: inherit;
+  overflow: auto;
+  margin: auto;
+  box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.25);
+  padding: 1rem;
+`
+
+export const Title = styled('h3')`
+  font-family: "OpenSans", Helvetica, sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+`
+
+export const Sub = styled('h4')`
+  font-family: "OpenSans", Helvetica, sans-serif;
+  font-size: 0.9rem;
+  font-weight: 600;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: 1.43;
+  letter-spacing: 0.25px;
+`
+
+export const Value = styled('div')`
+  font-weight: normal;
+  color: #616161;
+  text-transform: capitalize;
+`
+
+const Panel = () => {
+  const nodes = useStoreState((store) => store.nodes)
+  const [{ id: selected } = {}] = useStoreState((store) => store.selectedElements || [])
+  const { data = {} } = nodes.find(({ id }) => id === selected) || {}
+  const { name, sub, period, price = {}, dag = {} } = data
+
+  if (!Object.keys(data).length) {
+    return null
+  }
+
+  return (
+    <Container>
+      <Title>
+        {name}
+        {period ? ` (${period})` : ''}
+        {sub ? `: ${sub}` : ''}
+      </Title>
+      {dag.state && (
+        <Sub>
+          Status
+          <Value>
+            {dag.state}
+            {' '}
+            <Dot state={dag.state} />
+          </Value>
+        </Sub>
+      )}
+      {dag.duration && (
+        <Sub>
+          Run time
+          <Value>{humanTime(dag.duration)}</Value>
+        </Sub>
+      )}
+      {Object.keys(price).length > 0 && (
+        <Sub>
+          Price
+          <Value>${calcPrice(price)}</Value>
+        </Sub>
+      )}
+    </Container>
+  )
+}
+
+export default Panel

--- a/src/flow/utils.js
+++ b/src/flow/utils.js
@@ -305,3 +305,5 @@ export const humanTime = (seconds) => {
   }
   return parts.join(' ')
 }
+
+export const calcPrice = ({ base = 0, mult = 1, add = 0 }) => (base * mult) + add

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,2 @@
 export { default as Visual } from './visual'
 export { default as Flow } from './flow'
-export { default as Flow2 } from './flow2'
-export { default as Flow4 } from './flow4'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7524,6 +7524,11 @@ react-textarea-autosize@^7.1.0:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
+react-virtualized-auto-sizer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz#a61dd4f756458bbf63bd895a92379f9b70f803bd"
+  integrity sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg==
+
 react@^16.8.3, react@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"


### PR DESCRIPTION

<img width="1510" alt="panel" src="https://user-images.githubusercontent.com/2837532/92673937-4b6e2480-f2ea-11ea-8d84-ce0c58f1dbd6.png">

also comes with better resize detection (back to use `react-virtualized-auto-sizer`)

rolling from #11 